### PR TITLE
Add support for step for any number field

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ what][formsupport])
 * __Additional Options:__
     * `maxValue`: the largest allowed value for this control
     * `minValue`: the smallest allowed value for this control
+    * `step`: the amount by which the control can increase or decrease in value
     * Also see [text](#text) below
 * __Other Notes:__
     * May not be [supported][numbersupport] in all browsers

--- a/dynamic-forms.js
+++ b/dynamic-forms.js
@@ -120,9 +120,7 @@ angular.module('dynform', [])
                 if (field.type === 'number' || field.type === 'range') {
                   if (angular.isDefined(field.minValue)) {newElement.attr('min', field.minValue);}
                   if (angular.isDefined(field.maxValue)) {newElement.attr('max', field.maxValue);}
-                  if (field.type === 'range') {
-                    if (angular.isDefined(field.step)) {newElement.attr('step', field.step);}
-                  }
+                  if (angular.isDefined(field.step)) {newElement.attr('step', field.step);}
                 }
                 else if (['text', 'textarea'].indexOf(field.type) > -1) {
                   if (angular.isDefined(field.splitBy)) {newElement.attr('ng-list', field.splitBy);}


### PR DESCRIPTION
For a number field that is representing a floating point number, the step
needs to be set to a value smaller than 1 or to "any", otherwise the browser
will reject any decimal places.
