### PR TITLE
Changed template to accept arrays of objects

### DIFF
--- a/dynamic-forms.js
+++ b/dynamic-forms.js
@@ -88,239 +88,241 @@ angular.module('dynform', [])
               props = model.split('.');
               return (base || props.shift()) + (props.length ? "['" + props.join("']['") + "']" : '');
             },
-            buildFields = function (field, id) {
-              if (String(id).charAt(0) == '$') {
-                // Don't process keys added by Angular...  See GitHub Issue #29
-                return;
-              }
-              else if (!angular.isDefined(supported[field.type]) || supported[field.type] === false) {
-                //  Unsupported.  Create SPAN with field.label as contents
-                newElement = angular.element('<span></span>');
-                if (angular.isDefined(field.label)) {angular.element(newElement).html(field.label);}
-                angular.forEach(field, function (val, attr) {
-                  if (["label", "type"].indexOf(attr) > -1) {return;}
-                  newElement.attr(attr, val);
-                });
-                this.append(newElement);
-                newElement = null;
-              }
-              else {
-                //  Supported.  Create element (or container) according to type
-                if (!angular.isDefined(field.model)) {
-                  field.model = id;
+            buildFields = function (fields, id) {
+              fields.forEach(function (field) {
+                if (String(id).charAt(0) == '$') {
+                  // Don't process keys added by Angular...  See GitHub Issue #29
+                  return;
                 }
-                
-                newElement = angular.element($document[0].createElement(supported[field.type].element));
-                if (angular.isDefined(supported[field.type].type)) {
-                  newElement.attr('type', supported[field.type].type);
-                }
-                
-                //  Editable fields (those that can feed models)
-                if (angular.isDefined(supported[field.type].editable) && supported[field.type].editable) {
-                  newElement.attr('name', bracket(field.model));
-                  newElement.attr('ng-model', bracket(field.model, attrs.ngModel));
-                  // Build parent in case of a nested model
-                  setProperty(model, field.model, {}, null, true);
-                    
-                  if (angular.isDefined(field.readonly)) {newElement.attr('ng-readonly', field.readonly);}
-                  if (angular.isDefined(field.required)) {newElement.attr('ng-required', field.required);}
-                  if (angular.isDefined(field.val)) {
-                    setProperty(model, field.model, angular.copy(field.val));
-                    newElement.attr('value', field.val);
-                  }
-                }
-                
-                //  Fields based on input type=text
-                if (angular.isDefined(supported[field.type].textBased) && supported[field.type].textBased) {
-                  if (angular.isDefined(field.minLength)) {newElement.attr('ng-minlength', field.minLength);}
-                  if (angular.isDefined(field.maxLength)) {newElement.attr('ng-maxlength', field.maxLength);}
-                  if (angular.isDefined(field.validate)) {newElement.attr('ng-pattern', field.validate);}
-                  if (angular.isDefined(field.placeholder)) {newElement.attr('placeholder', field.placeholder);}
-                }
-                
-                //  Special cases
-                if (field.type === 'number' || field.type === 'range') {
-                  if (angular.isDefined(field.minValue)) {newElement.attr('min', field.minValue);}
-                  if (angular.isDefined(field.maxValue)) {newElement.attr('max', field.maxValue);}
-                  if (angular.isDefined(field.step)) {newElement.attr('step', field.step);}
-                }
-                else if (['text', 'textarea'].indexOf(field.type) > -1) {
-                  if (angular.isDefined(field.splitBy)) {newElement.attr('ng-list', field.splitBy);}
-                }
-                else if (field.type === 'checkbox') {
-                  if (angular.isDefined(field.isOn)) {newElement.attr('ng-true-value', field.isOn);}
-                  if (angular.isDefined(field.isOff)) {newElement.attr('ng-false-value', field.isOff);}
-                  if (angular.isDefined(field.slaveTo)) {newElement.attr('ng-checked', field.slaveTo);}
-                }
-                else if (field.type === 'checklist') {
-                  if (angular.isDefined(field.val)) {
-                    setProperty(model, field.model, angular.copy(field.val));
-                  }
-                  if (angular.isDefined(field.options)) {
-                    if (! (angular.isDefined(model[field.model]) && angular.isObject(model[field.model]))) {
-                      setProperty(model, field.model, {});
-                    }
-                    angular.forEach(field.options, function (option, childId) {
-                      newChild = angular.element('<input type="checkbox" />');
-                      newChild.attr('name', bracket(field.model + '.' + childId));
-                      newChild.attr('ng-model', bracket(field.model + "." + childId, attrs.ngModel));
-                      if (angular.isDefined(option['class'])) {newChild.attr('ng-class', option['class']);}
-                      if (angular.isDefined(field.disabled)) {newChild.attr('ng-disabled', field.disabled);}
-                      if (angular.isDefined(field.readonly)) {newChild.attr('ng-readonly', field.readonly);}
-                      if (angular.isDefined(field.required)) {newChild.attr('ng-required', field.required);}
-                      if (angular.isDefined(field.callback)) {newChild.attr('ng-change', field.callback);}
-                      if (angular.isDefined(option.isOn)) {newChild.attr('ng-true-value', option.isOn);}
-                      if (angular.isDefined(option.isOff)) {newChild.attr('ng-false-value', option.isOff);}
-                      if (angular.isDefined(option.slaveTo)) {newChild.attr('ng-checked', option.slaveTo);}
-                      if (angular.isDefined(option.val)) {
-                        setProperty(model, field.model, angular.copy(option.val), childId);
-                        newChild.attr('value', option.val);
-                      }
-                      
-                      if (angular.isDefined(option.label)) {
-                          newChild = newChild.wrap('<label></label>').parent();
-                          newChild.append(document.createTextNode(' ' + option.label));
-                      }
-                      newElement.append(newChild);
-                    });
-                  }
-                }
-                else if (field.type === 'radio') {
-                  if (angular.isDefined(field.val)) {
-                    setProperty(model, field.model, angular.copy(field.val));
-                  }
-                  if (angular.isDefined(field.values)) {
-                    angular.forEach(field.values, function (label, val) {
-                      newChild = angular.element('<input type="radio" />');
-                      newChild.attr('name', bracket(field.model));
-                      newChild.attr('ng-model', bracket(field.model, attrs.ngModel));
-                      if (angular.isDefined(field['class'])) {newChild.attr('ng-class', field['class']);}
-                      if (angular.isDefined(field.disabled)) {newChild.attr('ng-disabled', field.disabled);}
-                      if (angular.isDefined(field.callback)) {newChild.attr('ng-change', field.callback);}
-                      if (angular.isDefined(field.readonly)) {newChild.attr('ng-readonly', field.readonly);}
-                      if (angular.isDefined(field.required)) {newChild.attr('ng-required', field.required);}
-                      newChild.attr('value', val);
-                      if (angular.isDefined(field.val) && field.val === val) {newChild.attr('checked', 'checked');}
-                      
-                      if (label) {
-                          newChild = newChild.wrap('<label></label>').parent();
-                          newChild.append(document.createTextNode(' ' + label));
-                      }
-                      newElement.append(newChild);
-                    });
-                  }
-                }
-                else if (field.type === 'select') {
-                  if (angular.isDefined(field.multiple) && field.multiple !== false) {newElement.attr('multiple', 'multiple');}
-                  if (angular.isDefined(field.empty) && field.empty !== false) {newElement.append(angular.element($document[0].createElement('option')).attr('value', '').html(field.empty));}
-                  
-                  if (angular.isDefined(field.autoOptions)) {
-                    newElement.attr('ng-options', field.autoOptions);
-                  }
-                  else if (angular.isDefined(field.options)) {
-                    angular.forEach(field.options, function (option, childId) {
-                      newChild = angular.element($document[0].createElement('option'));
-                      newChild.attr('value', childId);
-                      if (angular.isDefined(option.disabled)) {newChild.attr('ng-disabled', option.disabled);}
-                      if (angular.isDefined(option.slaveTo)) {newChild.attr('ng-selected', option.slaveTo);}
-                      if (angular.isDefined(option.label)) {newChild.html(option.label);}
-                      if (angular.isDefined(option.group)) {
-                        if (!angular.isDefined(optGroups[option.group])) {
-                          optGroups[option.group] = angular.element($document[0].createElement('optgroup'));
-                          optGroups[option.group].attr('label', option.group);
-                        }
-                        optGroups[option.group].append(newChild);
-                      }
-                      else {
-                        newElement.append(newChild);
-                      }
-                    });
-                    
-                    if (!angular.equals(optGroups, {})) {
-                      angular.forEach(optGroups, function (optGroup) {
-                        newElement.append(optGroup);
-                      });
-                      optGroups = {};
-                    }
-                  }
-                }
-                else if (field.type === 'image') {
-                  if (angular.isDefined(field.label)) {newElement.attr('alt', field.label);}
-                  if (angular.isDefined(field.source)) {newElement.attr('src', field.source);}
-                }
-                else if (field.type === 'hidden') {
-                  newElement.attr('name', bracket(field.model));
-                  newElement.attr('ng-model', bracket(field.model, attrs.ngModel));
-                  if (angular.isDefined(field.val)) {
-                    setProperty(model, field.model, angular.copy(field.val));
-                    newElement.attr('value', field.val);
-                  }
-                }
-                else if (field.type === 'file') {
-                  if (angular.isDefined(field.multiple)) {
-                    newElement.attr('multiple', field.multiple);
-                  }
-                }
-                else if (field.type === 'fieldset') {
-                  if (angular.isDefined(field.fields)) {
-                    var workingElement = newElement;
-                    angular.forEach(field.fields, buildFields, newElement);
-                    newElement = workingElement;
-                  }
-                }
-                
-                //  Common attributes; radio already applied these...
-                if (field.type !== "radio") {
-                  if (angular.isDefined(field['class'])) {newElement.attr('ng-class', field['class']);}
-                  //  ...and checklist has already applied these.
-                  if (field.type !== "checklist") {
-                    if (angular.isDefined(field.disabled)) {newElement.attr('ng-disabled', field.disabled);}
-                    if (angular.isDefined(field.callback)) {
-                      //  Some input types need listeners on click...
-                      if (["button", "fieldset", "image", "legend", "reset", "submit"].indexOf(field.type) > -1) {
-                        cbAtt = 'ng-click';
-                      }
-                      //  ...the rest on change.
-                      else {
-                        cbAtt = 'ng-change';
-                      }
-                      newElement.attr(cbAtt, field.callback);
-                    }
-                  }
-                }
-                
-                //  If there's a label, add it.
-                if (angular.isDefined(field.label)) {
-                  //  Some elements have already applied their labels.
-                  if (["image", "hidden"].indexOf(field.type) > -1) {
-                    angular.noop();
-                  }
-                  //  Fieldset elements put their labels in legend child elements.
-                  else if (["fieldset"].indexOf(field.type) > -1) {
-                    newElement.prepend(angular.element($document[0].createElement('legend')).html(field.label));
-                  }
-                  //  Button elements get their labels from their contents.
-                  else if (["button", "legend", "reset", "submit"].indexOf(field.type) > -1) {
-                    newElement.html(field.label);
-                  }
-                  //  Everything else should be wrapped in a label tag.
-                  else {
-                    newElement = newElement.wrap('<label></label>').parent();
-                    newElement.prepend(document.createTextNode(field.label + ' '));
-                  }
-                }
-                
-                // Arbitrary attributes
-                if (angular.isDefined(field.attributes)) {
-                  angular.forEach(field.attributes, function (val, attr) {
+                else if (!angular.isDefined(supported[field.type]) || supported[field.type] === false) {
+                  //  Unsupported.  Create SPAN with field.label as contents
+                  newElement = angular.element('<span></span>');
+                  if (angular.isDefined(field.label)) {angular.element(newElement).html(field.label);}
+                  angular.forEach(field, function (val, attr) {
+                    if (["label", "type"].indexOf(attr) > -1) {return;}
                     newElement.attr(attr, val);
                   });
+                  this.append(newElement);
+                  newElement = null;
                 }
-                
-                // Add the element to the page
-                this.append(newElement);
-                newElement = null;
-              }
+                else {
+                  //  Supported.  Create element (or container) according to type
+                  if (!angular.isDefined(field.model)) {
+                    field.model = id;
+                  }
+                  
+                  newElement = angular.element($document[0].createElement(supported[field.type].element));
+                  if (angular.isDefined(supported[field.type].type)) {
+                    newElement.attr('type', supported[field.type].type);
+                  }
+                  
+                  //  Editable fields (those that can feed models)
+                  if (angular.isDefined(supported[field.type].editable) && supported[field.type].editable) {
+                    newElement.attr('name', bracket(field.model));
+                    newElement.attr('ng-model', bracket(field.model, attrs.ngModel));
+                    // Build parent in case of a nested model
+                    setProperty(model, field.model, {}, null, true);
+                      
+                    if (angular.isDefined(field.readonly)) {newElement.attr('ng-readonly', field.readonly);}
+                    if (angular.isDefined(field.required)) {newElement.attr('ng-required', field.required);}
+                    if (angular.isDefined(field.val)) {
+                      setProperty(model, field.model, angular.copy(field.val));
+                      newElement.attr('value', field.val);
+                    }
+                  }
+                  
+                  //  Fields based on input type=text
+                  if (angular.isDefined(supported[field.type].textBased) && supported[field.type].textBased) {
+                    if (angular.isDefined(field.minLength)) {newElement.attr('ng-minlength', field.minLength);}
+                    if (angular.isDefined(field.maxLength)) {newElement.attr('ng-maxlength', field.maxLength);}
+                    if (angular.isDefined(field.validate)) {newElement.attr('ng-pattern', field.validate);}
+                    if (angular.isDefined(field.placeholder)) {newElement.attr('placeholder', field.placeholder);}
+                  }
+                  
+                  //  Special cases
+                  if (field.type === 'number' || field.type === 'range') {
+                    if (angular.isDefined(field.minValue)) {newElement.attr('min', field.minValue);}
+                    if (angular.isDefined(field.maxValue)) {newElement.attr('max', field.maxValue);}
+                    if (angular.isDefined(field.step)) {newElement.attr('step', field.step);}
+                  }
+                  else if (['text', 'textarea'].indexOf(field.type) > -1) {
+                    if (angular.isDefined(field.splitBy)) {newElement.attr('ng-list', field.splitBy);}
+                  }
+                  else if (field.type === 'checkbox') {
+                    if (angular.isDefined(field.isOn)) {newElement.attr('ng-true-value', field.isOn);}
+                    if (angular.isDefined(field.isOff)) {newElement.attr('ng-false-value', field.isOff);}
+                    if (angular.isDefined(field.slaveTo)) {newElement.attr('ng-checked', field.slaveTo);}
+                  }
+                  else if (field.type === 'checklist') {
+                    if (angular.isDefined(field.val)) {
+                      setProperty(model, field.model, angular.copy(field.val));
+                    }
+                    if (angular.isDefined(field.options)) {
+                      if (! (angular.isDefined(model[field.model]) && angular.isObject(model[field.model]))) {
+                        setProperty(model, field.model, {});
+                      }
+                      angular.forEach(field.options, function (option, childId) {
+                        newChild = angular.element('<input type="checkbox" />');
+                        newChild.attr('name', bracket(field.model + '.' + childId));
+                        newChild.attr('ng-model', bracket(field.model + "." + childId, attrs.ngModel));
+                        if (angular.isDefined(option['class'])) {newChild.attr('ng-class', option['class']);}
+                        if (angular.isDefined(field.disabled)) {newChild.attr('ng-disabled', field.disabled);}
+                        if (angular.isDefined(field.readonly)) {newChild.attr('ng-readonly', field.readonly);}
+                        if (angular.isDefined(field.required)) {newChild.attr('ng-required', field.required);}
+                        if (angular.isDefined(field.callback)) {newChild.attr('ng-change', field.callback);}
+                        if (angular.isDefined(option.isOn)) {newChild.attr('ng-true-value', option.isOn);}
+                        if (angular.isDefined(option.isOff)) {newChild.attr('ng-false-value', option.isOff);}
+                        if (angular.isDefined(option.slaveTo)) {newChild.attr('ng-checked', option.slaveTo);}
+                        if (angular.isDefined(option.val)) {
+                          setProperty(model, field.model, angular.copy(option.val), childId);
+                          newChild.attr('value', option.val);
+                        }
+                        
+                        if (angular.isDefined(option.label)) {
+                            newChild = newChild.wrap('<label></label>').parent();
+                            newChild.append(document.createTextNode(' ' + option.label));
+                        }
+                        newElement.append(newChild);
+                      });
+                    }
+                  }
+                  else if (field.type === 'radio') {
+                    if (angular.isDefined(field.val)) {
+                      setProperty(model, field.model, angular.copy(field.val));
+                    }
+                    if (angular.isDefined(field.values)) {
+                      angular.forEach(field.values, function (label, val) {
+                        newChild = angular.element('<input type="radio" />');
+                        newChild.attr('name', bracket(field.model));
+                        newChild.attr('ng-model', bracket(field.model, attrs.ngModel));
+                        if (angular.isDefined(field['class'])) {newChild.attr('ng-class', field['class']);}
+                        if (angular.isDefined(field.disabled)) {newChild.attr('ng-disabled', field.disabled);}
+                        if (angular.isDefined(field.callback)) {newChild.attr('ng-change', field.callback);}
+                        if (angular.isDefined(field.readonly)) {newChild.attr('ng-readonly', field.readonly);}
+                        if (angular.isDefined(field.required)) {newChild.attr('ng-required', field.required);}
+                        newChild.attr('value', val);
+                        if (angular.isDefined(field.val) && field.val === val) {newChild.attr('checked', 'checked');}
+                        
+                        if (label) {
+                            newChild = newChild.wrap('<label></label>').parent();
+                            newChild.append(document.createTextNode(' ' + label));
+                        }
+                        newElement.append(newChild);
+                      });
+                    }
+                  }
+                  else if (field.type === 'select') {
+                    if (angular.isDefined(field.multiple) && field.multiple !== false) {newElement.attr('multiple', 'multiple');}
+                    if (angular.isDefined(field.empty) && field.empty !== false) {newElement.append(angular.element($document[0].createElement('option')).attr('value', '').html(field.empty));}
+                    
+                    if (angular.isDefined(field.autoOptions)) {
+                      newElement.attr('ng-options', field.autoOptions);
+                    }
+                    else if (angular.isDefined(field.options)) {
+                      angular.forEach(field.options, function (option, childId) {
+                        newChild = angular.element($document[0].createElement('option'));
+                        newChild.attr('value', childId);
+                        if (angular.isDefined(option.disabled)) {newChild.attr('ng-disabled', option.disabled);}
+                        if (angular.isDefined(option.slaveTo)) {newChild.attr('ng-selected', option.slaveTo);}
+                        if (angular.isDefined(option.label)) {newChild.html(option.label);}
+                        if (angular.isDefined(option.group)) {
+                          if (!angular.isDefined(optGroups[option.group])) {
+                            optGroups[option.group] = angular.element($document[0].createElement('optgroup'));
+                            optGroups[option.group].attr('label', option.group);
+                          }
+                          optGroups[option.group].append(newChild);
+                        }
+                        else {
+                          newElement.append(newChild);
+                        }
+                      });
+                      
+                      if (!angular.equals(optGroups, {})) {
+                        angular.forEach(optGroups, function (optGroup) {
+                          newElement.append(optGroup);
+                        });
+                        optGroups = {};
+                      }
+                    }
+                  }
+                  else if (field.type === 'image') {
+                    if (angular.isDefined(field.label)) {newElement.attr('alt', field.label);}
+                    if (angular.isDefined(field.source)) {newElement.attr('src', field.source);}
+                  }
+                  else if (field.type === 'hidden') {
+                    newElement.attr('name', bracket(field.model));
+                    newElement.attr('ng-model', bracket(field.model, attrs.ngModel));
+                    if (angular.isDefined(field.val)) {
+                      setProperty(model, field.model, angular.copy(field.val));
+                      newElement.attr('value', field.val);
+                    }
+                  }
+                  else if (field.type === 'file') {
+                    if (angular.isDefined(field.multiple)) {
+                      newElement.attr('multiple', field.multiple);
+                    }
+                  }
+                  else if (field.type === 'fieldset') {
+                    if (angular.isDefined(field.fields)) {
+                      var workingElement = newElement;
+                      angular.forEach(field.fields, buildFields, newElement);
+                      newElement = workingElement;
+                    }
+                  }
+                  
+                  //  Common attributes; radio already applied these...
+                  if (field.type !== "radio") {
+                    if (angular.isDefined(field['class'])) {newElement.attr('ng-class', field['class']);}
+                    //  ...and checklist has already applied these.
+                    if (field.type !== "checklist") {
+                      if (angular.isDefined(field.disabled)) {newElement.attr('ng-disabled', field.disabled);}
+                      if (angular.isDefined(field.callback)) {
+                        //  Some input types need listeners on click...
+                        if (["button", "fieldset", "image", "legend", "reset", "submit"].indexOf(field.type) > -1) {
+                          cbAtt = 'ng-click';
+                        }
+                        //  ...the rest on change.
+                        else {
+                          cbAtt = 'ng-change';
+                        }
+                        newElement.attr(cbAtt, field.callback);
+                      }
+                    }
+                  }
+                  
+                  //  If there's a label, add it.
+                  if (angular.isDefined(field.label)) {
+                    //  Some elements have already applied their labels.
+                    if (["image", "hidden"].indexOf(field.type) > -1) {
+                      angular.noop();
+                    }
+                    //  Fieldset elements put their labels in legend child elements.
+                    else if (["fieldset"].indexOf(field.type) > -1) {
+                      newElement.prepend(angular.element($document[0].createElement('legend')).html(field.label));
+                    }
+                    //  Button elements get their labels from their contents.
+                    else if (["button", "legend", "reset", "submit"].indexOf(field.type) > -1) {
+                      newElement.html(field.label);
+                    }
+                    //  Everything else should be wrapped in a label tag.
+                    else {
+                      newElement = newElement.wrap('<label></label>').parent();
+                      newElement.prepend(document.createTextNode(field.label + ' '));
+                    }
+                  }
+                  
+                  // Arbitrary attributes
+                  if (angular.isDefined(field.attributes)) {
+                    angular.forEach(field.attributes, function (val, attr) {
+                      newElement.attr(attr, val);
+                    });
+                  }
+                  
+                  // Add the element to the page
+                  this.append(newElement);
+                  newElement = null;
+                }
+              }, this);
             };
             
             angular.forEach(template, buildFields, element);


### PR DESCRIPTION
This allows you to add multiple sets of fields to a single template property.  This comes in handy if you want to have multiple check-lists in the same property to have sub sections.  This probably won't work well for other types of fields like radios and such as the values are still stored under the single property name.

References: Issue #44 